### PR TITLE
Changes to make releases to maven central possible

### DIFF
--- a/.github/workflows/maven-deploy.yaml
+++ b/.github/workflows/maven-deploy.yaml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   maven-deploy:
-    uses: rcsb/devops-cicd-github-actions/.github/workflows/maven-deploy.yaml@master
+    uses: rcsb/devops-cicd-github-actions/.github/workflows/run-tests.yaml@master

--- a/pom.xml
+++ b/pom.xml
@@ -13,22 +13,22 @@
         <slf4j.version>2.0.9</slf4j.version>
         <log4j.version>2.22.0</log4j.version>
         <junit.version>5.10.1</junit.version>
+        <!-- This is for the release plugin not to generate backup poms (annoying behaviour if you have git) -->
+        <generateBackupPoms>false</generateBackupPoms>
     </properties>
 
+    <!-- https://central.sonatype.org/pages/apache-maven.html -->
+    <!-- https://github.com/chhh/sonatype-ossrh-parent/blob/master/pom.xml -->
     <distributionManagement>
-        <downloadUrl>https://nexus3.rcsb.org/repository/rcsb-super-proxy/</downloadUrl>
-        <repository>
-            <id>releases</id>
-            <name>RCSB PDB Maven Repository</name>
-            <url>https://nexus3.rcsb.org/repository/maven-releases/</url>
-        </repository>
         <snapshotRepository>
-            <id>snapshots</id>
-            <url>https://nexus3.rcsb.org/repository/maven-snapshots/</url>
-            <uniqueVersion>false</uniqueVersion>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
     </distributionManagement>
-
     <scm>
         <url>https://github.com/rcsb/rcsb-util</url>
         <connection>scm:git:git://github.com/rcsb/rcsb-util.git</connection>
@@ -81,6 +81,7 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
@@ -88,6 +89,88 @@
                     <target>${jdk.version}</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>3.0.1</version>
+            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <!-- A profile only to be used when releasing-->
+            <id>release</id>
+            <build>
+                <plugins>
+                    <!-- handles propagating the build to the staging repository -->
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.13</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+
+                    <!-- signing of content to be published -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <!-- This is necessary for gpg to not try to use the pinentry programs -->
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- create source -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.3.0</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- create javadoc -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.6.3</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,6 @@
         <slf4j.version>2.0.9</slf4j.version>
         <log4j.version>2.22.0</log4j.version>
         <junit.version>5.10.1</junit.version>
-        <!-- This is for the release plugin not to generate backup poms (annoying behaviour if you have git) -->
-        <generateBackupPoms>false</generateBackupPoms>
     </properties>
 
     <!-- https://central.sonatype.org/pages/apache-maven.html -->

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,11 @@
                                 </goals>
                             </execution>
                         </executions>
+                        <configuration>
+                            <!-- so that javadoc generator is not so strict about missing docs -->
+                            <!-- https://stackoverflow.com/questions/15886209/maven-is-not-working-in-java-8-when-javadoc-tags-are-incomplete -->
+                            <doclint>none</doclint>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
This also disables the deploy workflow. Now the workflow runs tests only. Releases must be manual using the release plugin.

FYI @dmyersturnbull 

I'll merge soon and try out an actual release.